### PR TITLE
fix up build error ‘uintptr_t’ undeclared

### DIFF
--- a/test/check_an_array.c
+++ b/test/check_an_array.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <stdint.h>
 
 #include "an_array.h"
 


### PR DESCRIPTION
Build error is
```
[ 66%] Building C object test/CMakeFiles/check_an_array.dir/check_an_array.c.o
In file included from /home/liuqun/Desktop/acf/test/check_an_array.c:2:0:
/home/liuqun/Desktop/acf/test/check_an_array.c: In function ‘stack_generic’:
/home/liuqun/Desktop/acf/test/check_an_array.c:80:12: error: ‘uintptr_t’ undeclared (first use in this function)
   fail_if((uintptr_t)cursor->value != (uintptr_t)i++);
            ^
/home/liuqun/Desktop/acf/test/check_an_array.c:80:12: note: each undeclared identifier is reported only once for each function it appears in
/home/liuqun/Desktop/acf/test/check_an_array.c:80:22: error: expected ‘)’ before ‘cursor’
   fail_if((uintptr_t)cursor->value != (uintptr_t)i++);
                      ^
/home/liuqun/Desktop/acf/test/check_an_array.c:85:22: error: expected ‘)’ before ‘cursor’
   fail_if((uintptr_t)cursor->value != (uintptr_t)i++);
                      ^
/home/liuqun/Desktop/acf/test/check_an_array.c:94:22: error: expected ‘)’ before ‘n’
   fail_if((uintptr_t)n->value != (uintptr_t)i - 1);
                      ^
/home/liuqun/Desktop/acf/test/check_an_array.c:90:16: error: variable ‘n’ set but not used [-Werror=unused-but-set-variable]
   struct node *n;
                ^
/home/liuqun/Desktop/acf/test/check_an_array.c:70:15: error: variable ‘cursor’ set but not used [-Werror=unused-but-set-variable]
  struct node *cursor;
               ^
cc1: all warnings being treated as errors
```

Bug found in CentOS 7.7(and 7.6) with its default gcc 4.x:

`yum install gcc check-devel epel-release && yum install cmake3`
